### PR TITLE
Update CONTRIBUTORS.md

### DIFF
--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -59,3 +59,6 @@ TSC members are:
 | Cathy Zhang               | [cathyhongzhang](https://github.com/cathyhongzhang)   | Intel            |           |
 | Srinivasa Addepalli       | [saddepalli](https://github.com/saddepalli)           | Intel            |           |
 | Eric Multanen             | [snackewm](https://github.com/snackewm)               | Intel            |           |
+| Sudhindra Chada           | [sudhichada](https://github.com/sudhichada)           | Ericsson         |           |
+| Ciaran Johnston           | [ciaranjohnston](https://github.com/ciaranjohnston)   | Ericsson         |           |
+| Peter Worndle             | [peterwoerndle](https://github.com/peterwoerndle)     | Ericsson         |           |

--- a/CONTRIBUTORS.md
+++ b/CONTRIBUTORS.md
@@ -13,6 +13,7 @@ TSC members are:
   - Oleg Berzin, Equinix
   - Cathy Zhang, Intel
   - Fabrizio Moggio, TIM
+  - Sudhindra Chada, Ericsson
 
 ## Contributors and committers
 


### PR DESCRIPTION
Org: Ericsson
Sudhindra Chada will participate as the voting member in the TSC on behalf of Ericsson
Ciaran Johnston and Peter Worndle are the contributors.